### PR TITLE
Stop words not automatically charged in top terms calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ If you have a list of texts or a DataFrame with a column of texts then you can c
 texts = data.loc[:, 'text'].values.tolist()
 top_terms_algo = top_terms_extractor.top_terms_extractor()
 
-terms = top_terms_algo.compute_top_terms(texts=texts, n=10)
-for term, freq in terms.items():
-    print(f'{term}: {freq*100:.2f}%')
+top_terms = top_terms_algo.compute_top_terms(texts=texts, n=10)
+for term in top_terms:
+    print(f'{term["term"]}: {term["freq"]*100:.2f}%')
 ```
 
 ## Usage Trending Terms

--- a/ds_trends/top_terms_extractor.py
+++ b/ds_trends/top_terms_extractor.py
@@ -1,40 +1,15 @@
 import numpy as np
 from collections import Counter
-from nltk.util import ngrams
 import pandas as pd
-from os.path import join
-import ast
 import operator
 
 from sklearn.feature_extraction.text import CountVectorizer
-from nltk.corpus import stopwords
-
-######################################################stopwords###################################################################
-
-stop = stopwords.words('english')
-stop.extend(stopwords.words('spanish'))
-stop.extend(stopwords.words('french'))
-stop.extend(stopwords.words('portuguese'))
-stop.extend(['19','NUM','us', 'amp','https','co','get', 'dont', 'would', 'one', 'many', 'im', 'even', 'still', 'also', 'could', 'cant', 'much', 'isnt'
- 'thats', 'long', 'may', 'got', 'ive', 'yet', 'youre', 'ill', 'etc', 'lot', 'wont', 'didnt', 'two', 'theyre', 'theres', 'next'])
-stop.extend(['ingrese','ahora', 'van', 'va', 'fa','rt','decir', 'ser', 'solo', 'nunca', 'así', 'hoy', 'ir', 'dejar', 'además', 'según', 'cómo', 'menos', 'travès', 
-    'cada', 'varios', 'pues', 'mientras', 'después', 'luego', 'aquí', 'vía'])
-stop_fr = ['ça', 'plus', 'si', 'quand', 'comme', 'alors', 'jai', 'non', 'donc', 'car', 'cette', 'aussi', 'oui', 'sans', 
-     'là', 'quoi', 'après', 'parce', 'jamais', 'où', 'être', 'pourquoi', 'toujours', 'juste', 'contre', 'avant',
-     'vraiment', 'bon', 'mal', 'déjà', 'peut', 'être', 'surtout', 'très', 'sais', 'toutes', 'deux', 'autre', 'moins', 'aujourd', 'hui'
-     'sinon', 'sauf', 'sous', 'bah', 'maintenant', 'sens', 'vois', 'propos', 'reste', 'vu', 'ici', 'tout', 'tous', 'faut', 'encore', 
-     'jusqu', 'seul', 'devant', 'mec', 'trop', 'cela', 'aucune', 'chez', 'leurs', 'depuis', 'ceux', 'pareil', 'pire', 
-     'doit', 'comme']
-stop.extend(stop_fr)
-
-######################################################topterms###################################################################
 
 class top_terms_extractor:
         """A class to detect top terms and other features from text
 
         Attributes:
-        stop: A list of multilingual stopwords (en, es, fr, pr)
-        stop2: extra words that can be excluded depending on the project
+        stop_words: stop words that can be excluded depending on the project
         ngram_range, max_df, min_df: arguments for CountVectorizer
         vectorizer: An instance from CountVectorizer to count the freqs of words
 
@@ -44,14 +19,12 @@ class top_terms_extractor:
         categories: A dictionnary with categories and the top words representing the categories (get_words_freqs_by_category)
         """
         def __init__(self, **kwargs):
-            self.stop = stop 
-            self.stop2 = kwargs.get('stop_words', None)
-            if self.stop2!=None:
-                self.stop.extend(self.stop2)
-            self.vectorizer = CountVectorizer(ngram_range=kwargs.get('ngram_range',(1,2)), 
-                                              max_df=kwargs.get('max_df', 0.5),
-                                              min_df=kwargs.get('min_df', 0.001),
-                                              stop_words= self.stop)#.extend(kwargs.get('stop_words', []))
+            self.vectorizer = CountVectorizer(
+                ngram_range=kwargs.get('ngram_range',(1,2)), 
+                max_df=kwargs.get('max_df', 0.5),
+                min_df=kwargs.get('min_df', 0.001),
+                stop_words=kwargs.get('stop_words', [])
+            )
             
             self.words_freqs_ = {}
             self.top_terms={}

--- a/ds_trends/top_terms_extractor.py
+++ b/ds_trends/top_terms_extractor.py
@@ -74,6 +74,8 @@ class top_terms_extractor:
                     if (term["term"] + ' ' in term2["term"]) or (' ' + term["term"] in term2["term"]):
                         term["freq"] = term["freq"] - term2["freq"]
             self.top_terms = sorted(top_terms, key=lambda item: item["freq"], reverse=True)[:n]
+            # TODO: Some changes in the top_terms format may break the following code. But it is not used anywhere.
+            # should be reviewed if lemmas ara calculated.
             # if nlp!=None:
             #     top_terms = lemma_dict(top_terms, nlp)
             #     self.top_lemmas = dict(sorted(top_terms.items(), key=lambda item: item[1], reverse=True)[:n])


### PR DESCRIPTION
- Stop words not automatically loaded in top terms calculation
- Reformated top terms response, counts added

## QA Steps
#### Stop words
1. Execute
```
from ds_trends.top_terms_extractor import top_terms_extractor
top_terms_algo = top_terms_extractor()
top_terms_algo.compute_top_terms(texts=["bla blu bla and", "bla blu", "bla blu blu", "and vale vale vale"], n=10)
```
- [ ] `and` appears in the response
2. Execute:
```
from ds_trends.top_terms_extractor import top_terms_extractor
top_terms_algo = top_terms_extractor(stop_words=["and"])
top_terms_algo.compute_top_terms(texts=["bla blu bla and", "bla blu", "bla blu blu", "and vale vale vale"], n=10)
```
- [ ] `and` does not appears in the response

#### Counts in response
3. Play arount with different input texts
- [ ] check the term counts are correct